### PR TITLE
Capitalize grammar name

### DIFF
--- a/grammars/language-gitattributes.cson
+++ b/grammars/language-gitattributes.cson
@@ -1,4 +1,4 @@
-name: 'Git attributes'
+name: 'Git Attributes'
 scopeName: 'source.git-attributes'
 fileTypes: [
   'gitattributes'


### PR DESCRIPTION
Hi @ldez,

Grammar names in Atom are usually title-cased, as shown in the Grammar Selector below:

<img width="602" alt="screen shot 2017-10-14 at 3 09 36 pm" src="https://user-images.githubusercontent.com/872474/31579754-d5af97ac-b0f1-11e7-82e5-5c6c65e3b24c.png">

This package's grammar is not title-cased however, though I think it would look more consistent (and professional) if it followed suit. Please consider merging my PR with this fix.

Thanks,
Caleb